### PR TITLE
Fix NullInjectorError for MessagingService

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,10 +1,11 @@
 import { NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
+import { MessagingService } from './services/messaging.service';
 
 @NgModule({
   imports: [
     BrowserModule
   ],
-  providers: []
+  providers: [MessagingService]
 })
 export class AppModule { }

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,12 +6,14 @@ import { getMessaging, provideMessaging } from '@angular/fire/messaging';
 import { environment } from './environments/environment';
 import { importProvidersFrom } from '@angular/core';
 import { Messaging } from '@angular/fire/messaging';
+import { MessagingService } from './app/services/messaging.service';
 
 bootstrapApplication(AppComponent, {
   providers: [
     provideFirebaseApp(() => initializeApp(environment.firebase)),
     provideFirestore(() => getFirestore()),
     provideMessaging(() => getMessaging()),
-    importProvidersFrom(Messaging)
+    importProvidersFrom(Messaging),
+    MessagingService
   ]
 }).catch(err => console.error(err));


### PR DESCRIPTION
Related to #1

Resolve NullInjectorError for MessagingService by providing it in the application's module and main file.

* **src/app/app.module.ts**
  - Add `MessagingService` to the `providers` array.

* **src/main.ts**
  - Import `MessagingService`.
  - Add `MessagingService` to the `providers` array.

